### PR TITLE
Changing gunicorn for socketIO pro

### DIFF
--- a/charts/delta-reporter/Chart.yaml
+++ b/charts/delta-reporter/Chart.yaml
@@ -1,7 +1,7 @@
 name: delta-reporter
 description: Next generation reporting tool where results from all kind all tests are displayed in real time.
 type: application
-version: 0.1.22
-appVersion: 1.5.10
+version: 0.1.23
+appVersion: 1.5.11
 apiVersion: v1
 icon: https://raw.githubusercontent.com/delta-reporter/delta-reporter/master/site/logo-test.jpg

--- a/charts/delta-reporter/templates/delta-websockets-deployment.yaml
+++ b/charts/delta-reporter/templates/delta-websockets-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         args:
           - sh
           - -c
-          - gunicorn -b 0.0.0.0:{{ .Values.deployment.websockets.port }} app:app
+          - python app.py
         resources: {}
       restartPolicy: Always
       serviceAccountName: ""

--- a/charts/delta-reporter/values.yaml
+++ b/charts/delta-reporter/values.yaml
@@ -30,7 +30,7 @@ deployment:
     publicWebsocketsUrl: http://localhost:8080
     port: 3000
   websockets:
-    image: deltareporter/delta_websockets:v1.0
+    image: deltareporter/delta_websockets:v1.1
     appSettings: config.ProductionConfig
     port: 8080
   db:


### PR DESCRIPTION
I made a mistake, we don't need gunicorn as SockerIO could be used as a production-ready server